### PR TITLE
Update password check function prototype for OpenLDAP 2.6

### DIFF
--- a/check_password.c
+++ b/check_password.c
@@ -49,7 +49,7 @@ static validator valid_word (char *);
 static int set_quality (char *);
 static int set_cracklib (char *);
 
-int check_password (char *pPasswd, char **ppErrStr, Entry *pEntry);
+int check_password(char *pPasswd, struct berval *errmsg, Entry *pEntry, struct berval *arg);
 
 struct config_entry {
   char* key;
@@ -331,9 +331,7 @@ static int realloc_error_message (char ** target, int curlen, int nextlen)
 	return curlen;
 }
 
-	int
-check_password (char *pPasswd, char **ppErrStr, Entry *pEntry)
-{
+int check_password(char *pPasswd, struct berval *errmsg, Entry *pEntry, struct berval *arg) {
 
 	char *szErrStr = (char *) ber_memalloc(MEM_INIT_SZ);
 	int  mem_len = MEM_INIT_SZ;
@@ -584,14 +582,12 @@ check_password (char *pPasswd, char **ppErrStr, Entry *pEntry)
   print_config_entries();
 #endif
   dealloc_config_entries();
-	*ppErrStr = strdup ("");
-	ber_memfree(szErrStr);
+	errmsg->bv_val = szErrStr;
 	return (LDAP_SUCCESS);
 
 fail:
   dealloc_config_entries();
-	*ppErrStr = strdup (szErrStr);
-	ber_memfree(szErrStr);
+	errmsg->bv_val = szErrStr;
 	return (EXIT_FAILURE);
 
 }


### PR DESCRIPTION
The prototype of the `check_password()` function has changed in OpenLDAP 2.6

```diff
- int check_password( char *passwd, char **text, Entry *ent, struct berval *arg )
+ int check_password( char *passwd, struct berval *errmsg, Entry *ent, struct berval *arg )
```