### PR TITLE
Fix off-by-one in consecutive chars calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,8 @@ This check is independent of the quality points system: both must be satisfied u
 ##### Maximum Consecutive Characters (`max_consecutive_per_class`)
 
 This parameter sets the limit for consecutive characters from the same character class in a password.
-For example, if `max_consecutive_per_class` set to 5, a password may include up to 4 consecutive lowercase letters.
+For example, if `max_consecutive_per_class` set to 4, a password may include up to 4 consecutive lowercase letters.
 `abcdABCD1234` is valid, but `abcdeABCDE12345` exceeds the limit and is rejected.
-
-⚠️ Due to a bug, consecutive characters are counted incorrectly, so the effective limit is one less than the configured value. This behavior is preserved for compatibility with the original module.
 
 Setting the value to 0 disables this check.
 

--- a/check_password.c
+++ b/check_password.c
@@ -294,9 +294,9 @@ int check_password(char* pPasswd, struct berval* errmsg, Entry* pEntry,
 	 */
 
 	if (max_consecutive_per_class != 0) {
-		int consec_chars = 1;
-		char type[10] = "unkown";
-		char prev_type[10] = "unknown";
+		int consec_chars = 0;
+		char type[10] = "";
+		char prev_type[10] = "";
 		for (int i = 0; i < nLen; i++) {
 
 			if (islower(pPasswd[i])) {
@@ -311,21 +311,17 @@ int check_password(char* pPasswd, struct berval* errmsg, Entry* pEntry,
 				strncpy(type, "unknown", 10);
 			}
 
+			if (strncmp(type, prev_type, 10) == 0) {
+				consec_chars++;
+			} else {
+				consec_chars = 1;
+				strncpy(prev_type, type, 10);
+			}
+
 			if (consec_chars > max_consecutive_per_class) {
 				set_additional_info(errmsg, CONSEC_FAIL_SZ,
 									pEntry->e_name.bv_val);
 				goto fail;
-			}
-
-			if (strncmp(type, prev_type, 10) == 0) {
-				consec_chars++;
-			} else {
-				if (strncmp("unknown", prev_type, 8) != 0) {
-					consec_chars = 1;
-				} else {
-					consec_chars++;
-				}
-				strncpy(prev_type, type, 10);
 			}
 		}
 	}

--- a/tests/test-pwdcheck-rules.sh
+++ b/tests/test-pwdcheck-rules.sh
@@ -110,15 +110,16 @@ attempt_password_change "abcd!fgh/j"
 expect_no_message
 echo "[PASS] min_punct"
 
-# NOTE: max_consecutive_per_class counts wrong in current implementation, so we need to set 3 to allow 2 consecutive chars.
 echo "[TEST] max_consecutive_per_class..."
 set_pwd_check_module_arg <<EOF
 min_points 1
-max_consecutive_per_class 5
+max_consecutive_per_class 4
 use_cracklib 0
 EOF
 reset_password
 attempt_password_change "abcdeABCDE12345"
+expect_error_message "Too many consecutive characters in the same character class"
+attempt_password_change "abcdABCED1234!#$%&"
 expect_error_message "Too many consecutive characters in the same character class"
 attempt_password_change "abcdABCD1234"
 expect_no_message


### PR DESCRIPTION
This PR fixes a bug where consecutive characters are counted incorrectly, so the effective limit is one less than the configured value. When forking the code, this behavior was preserved for compatibility with the original module and it is now fixed in new major release.